### PR TITLE
Update `style.css`: underline links when hovering over

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -63,6 +63,7 @@ a:hover,
 a:focus {
   color: #069;
   font-weight: bold;
+  text-decoration: underline;
 }
 
 a small {


### PR DESCRIPTION
Related to [this](https://github.com/NYCPlanning/data-engineering/issues/1671) issue.

